### PR TITLE
商品詳細表示機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 | status_id           | integer    | null: false                    |
 | shipping_cost_id    | integer    | null: false                    |
 | prefecture_id       | integer    | null: false                    |
-| shipping_days_id    | integer    | null: false                    |
+| shipping_day_id     | integer    | null: false                    |
 | user                | references | null: false, foreign_key: true |
 
 ### Association

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,7 +19,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.new
+    @item = Item.find(params[:id])
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.new
+  end
+
   private
 
   def items_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,6 @@ class ItemsController < ApplicationController
   private
 
   def items_params
-    params.require(:item).permit(:name, :price, :description, :image, :category_id, :status_id, :shipping_cost_id, :prefecture_id, :shipping_days_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :price, :description, :image, :category_id, :status_id, :shipping_cost_id, :prefecture_id, :shipping_day_id).merge(user_id: current_user.id)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,7 +14,14 @@ class Item < ApplicationRecord
       validates :status_id
       validates :shipping_cost_id
       validates :prefecture_id
-      validates :shipping_days_id
+      validates :shipping_day_id
     end
   end
+
+  belongs_to :category
+  belongs_to :status
+  belongs_to :shipping_cost
+  belongs_to :prefecture
+  belongs_to :shipping_day
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,5 +23,4 @@ class Item < ApplicationRecord
   belongs_to :shipping_cost
   belongs_to :prefecture
   belongs_to :shipping_day
-
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% if @items.present? %>
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item.id) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -82,7 +82,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_days_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image.variant(resize: '500x500'), class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -19,7 +19,7 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= '配送料負担' %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,9 +30,8 @@
       <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <% if user_signed_in? %>
+    <% elsif user_signed_in? %>
       <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
@@ -106,7 +105,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href=“#” class=‘another-item’><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href=“#” class=‘another-item’><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,9 +9,11 @@
     <div class='item-img-content'>
       <%= image_tag @item.image.variant(resize: '500x500'), class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <% if @items.present? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -24,15 +26,16 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
-    <p class='or-text'>or</p>
-    <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <p class='or-text'>or</p>
+      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% if user_signed_in? %>
+      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end

--- a/db/migrate/20201211071115_create_items.rb
+++ b/db/migrate/20201211071115_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer    :status_id,        null: false
       t.integer    :shipping_cost_id, null: false
       t.integer    :prefecture_id,    null: false
-      t.integer    :shipping_days_id, null: false
+      t.integer    :shipping_day_id,  null: false
       t.references :user,             null: false, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2020_12_11_075214) do
     t.integer "status_id", null: false
     t.integer "shipping_cost_id", null: false
     t.integer "prefecture_id", null: false
-    t.integer "shipping_days_id", null: false
+    t.integer "shipping_day_id", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     status_id                  { 2 }
     shipping_cost_id           { 2 }
     prefecture_id              { 2 }
-    shipping_days_id           { 2 }
+    shipping_day_id            { 2 }
 
     association :user
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Item, type: :model do
 
     describe '商品出品機能' do
       context '商品出品がうまくいくとき' do
-        it 'image、name、price、description、category_id、status_id、shipping_cost_id、prefecture_id、shipping_days_idが存在すれば登録できる' do
+        it 'image、name、price、description、category_id、status_id、shipping_cost_id、prefecture_id、shipping_day_idが存在すれば登録できる' do
           expect(@item).to be_valid
         end
       end
@@ -51,10 +51,10 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Prefecture can't be blank")
       end
 
-      it 'shipping_days_idが空だと出品できない' do
-        @item.shipping_days_id = nil
+      it 'shipping_day_idが空だと出品できない' do
+        @item.shipping_day_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping days can't be blank")
+        expect(@item.errors.full_messages).to include("Shipping day can't be blank")
       end
 
       it 'priceが全角数字であれば出品できない' do
@@ -105,10 +105,10 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
       end
 
-      it 'shipping_days_idの値が1であれば出品できない' do
-        @item.shipping_days_id = 1
+      it 'shipping_day_idの値が1であれば出品できない' do
+        @item.shipping_day_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include('Shipping days must be other than 1')
+        expect(@item.errors.full_messages).to include('Shipping day must be other than 1')
       end
 
       it 'priceが半角英数混合では登録できない' do


### PR DESCRIPTION
#WHAT

・商品出品時に登録した情報がみられる
・画像の表示
・各ユーザーごとの条件分岐
・モデルとマイグレーションの名前が違ったため、修正
・アソシエーション修正
注）購入機能実装未のため、soldoutの表示実装未

#WHY

https://gyazo.com/0c360bc7771eac5a25fdbafebf0efc9f
ログインかつ商品出品ユーザー（test）にて、編集・削除ボタン表示
https://gyazo.com/e38cd3f742b8a32b81332f4f79bd072a
ログインユーザーかつ出品者以外のユーザー(test2)にて、購入進むボタン表示のみ
https://gyazo.com/2a00605b1076408e5ceeeeadb659377b
ログアウトユーザーはボタンなし　商品詳細ページはみられる
